### PR TITLE
feat: add support for driving file dialogs

### DIFF
--- a/mcp-server/index.mjs
+++ b/mcp-server/index.mjs
@@ -316,6 +316,46 @@ const TOOLS = [
       },
     },
   },
+  {
+    name: "qml_list_file_dialogs",
+    description:
+      "Lists file dialogs currently present in the application. For each dialog returns its " +
+      "type, id, objectName, visibility, and children. Note that some dialog types may be " +
+      "listed even while they are not visible/active. " +
+      "Workflow note: due to Qt limitations, the file selection often cannot be changed once a " +
+      "dialog is active. To select a file, call `file_dialog_actions` with action `select` BEFORE " +
+      "performing the step that opens the dialog (e.g. clicking the button that triggers it), not after.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+  {
+    name: "qml_file_dialog_action",
+    description:
+      "Interacts with an existing file dialog.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        objectId: {
+          type: "string",
+          description:
+            "ID of the dialog object to interact with."
+        },
+        action: {
+          type: "string",
+          enum: ["accept", "cancel", "select"],
+          description: "Action to perform on the dialog. 'accept' confirms the selection, 'cancel' dismisses the dialog, " +
+            "'select' selects a file/directory (requires a path to be provided)."
+        },
+        path: {
+          type: "string",
+          description: "Path to select (for 'select' action)."
+        }
+      },
+      required: ["objectId", "action"]
+    }
+  }
 ];
 
 // ---- Handlers ----
@@ -341,6 +381,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     qml_evaluate: "evaluate",
     qml_find_and_click: "findAndClick",
     qml_list_interactive: "listInteractive",
+    qml_list_file_dialogs: "listFileDialogs",
+    qml_file_dialog_action: "fileDialogAction",
   };
 
   const command = commandMap[name];

--- a/qt-plugin/inspectorserver.cpp
+++ b/qt-plugin/inspectorserver.cpp
@@ -25,6 +25,7 @@
 #include <QPointF>
 #include <QSizeF>
 #include <QFont>
+#include <QFileDialog>
 
 InspectorServer::InspectorServer(QObject *parent)
     : QObject(parent)
@@ -187,6 +188,10 @@ QJsonObject InspectorServer::handleCommand(const QJsonObject &request)
         result = cmdFindAndClick(params);
     else if (command == "listInteractive")
         result = cmdListInteractive(params);
+    else if (command == "listFileDialogs")
+        result = cmdListFileDialogs(params);
+    else if (command == "fileDialogAction")
+        result = cmdFileDialogAction(params);
     else
         result = errorResult(QString("Unknown command: %1").arg(command));
 
@@ -816,6 +821,41 @@ QJsonObject InspectorServer::cmdListInteractive(const QJsonObject &params)
     }
 
     return okResult({{"elements", results}, {"count", results.size()}});
+}
+
+QJsonObject InspectorServer::cmdListFileDialogs(const QJsonObject &params) {
+    QWidgetList widgets = QApplication::topLevelWidgets();
+    QJsonArray roots;
+    for (QWidget *widget : widgets) {
+        QString className = widget->metaObject()->className();
+        if (className == "QFileDialog") {
+            roots.append(serializeObject(widget, 1));
+        }
+    }
+    return okResult({{"dialogs", roots}});
+}
+
+QJsonObject InspectorServer::cmdFileDialogAction(const QJsonObject &params)
+{
+    QString objectId = params.value("objectId").toString();
+    QFileDialog *dialog = qobject_cast<QFileDialog*>(resolveObject(objectId));
+    if (!dialog) {
+        return errorResult("Object is not a file dialog: " + objectId);
+    }
+
+    QString action = params.value("action").toString();
+    if (action == "accept") {
+        // accept is protected, so we have to resort to this.
+        QMetaObject::invokeMethod(dialog, "accept");
+    } else if (action == "cancel") {
+        dialog->reject();
+    } else if (action == "select") {
+        dialog->selectFile(params.value("path").toString());
+    } else {
+        return errorResult("Unknown action: " + action);
+    }
+
+    return okResult();
 }
 
 // --- Serialization ---

--- a/qt-plugin/inspectorserver.cpp
+++ b/qt-plugin/inspectorserver.cpp
@@ -532,13 +532,20 @@ QJsonObject InspectorServer::cmdClick(const QJsonObject &params)
         target = child;
     }
 
-    QMouseEvent press(QEvent::MouseButtonPress, pos, globalPos,
-                      Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
-    QMouseEvent release(QEvent::MouseButtonRelease, pos, globalPos,
-                        Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+    // Events for postEvent must be heap-allocated. Qt will
+    // take care of freeing them.
+    QMouseEvent *press = new QMouseEvent(
+        QEvent::MouseButtonPress, pos, globalPos,
+        Qt::LeftButton, Qt::LeftButton, Qt::NoModifier
+    );
 
-    QApplication::sendEvent(target, &press);
-    QApplication::sendEvent(target, &release);
+    QMouseEvent *release = new QMouseEvent(
+        QEvent::MouseButtonRelease, pos, globalPos,
+        Qt::LeftButton, Qt::NoButton, Qt::NoModifier
+    );
+
+    QApplication::postEvent(target, press);
+    QApplication::postEvent(target, release);
 
     return okResult({{"clicked", true}, {"x", x}, {"y", y},
                      {"widget", QString::fromUtf8(target->metaObject()->className())}});

--- a/qt-plugin/inspectorserver.cpp
+++ b/qt-plugin/inspectorserver.cpp
@@ -801,10 +801,12 @@ QJsonObject InspectorServer::cmdFileDialogAction(const QJsonObject &params)
         return errorResult("Object not found: " + objectId);
 
     bool isQDialog = dialog->inherits("QDialog");
-    if (!(isQDialog || dialog->inherits("QQuickAbstractDialog"))) {
+    if (!(isQDialog || dialog->inherits("QQuickFileDialog"))) {
         return errorResult("Object is not a file dialog: " + objectId);
     }
 
+    // Since QQuickFileDialog requires that anyway,
+    // just use invokeMethod all over for simplicity.
     QString action = params.value("action").toString();
     if (action == "accept") {
         QMetaObject::invokeMethod(dialog, "accept");
@@ -864,12 +866,12 @@ QJsonObject InspectorServer::serializeObject(QObject *obj, int maxDepth, int cur
     // QQuickFileDialog geometry.
     // We need to resort to the metaobject protocol as QQuickDialog has no
     // public C++ API. This is, of course, brittle, and might break with
-    // future versions maintenance releases of Qt.
+    // (minor) future versions releases of Qt.
     if (obj->inherits("QQuickAbstractDialog")) {
         result["title"] = obj->property("title").toString();
         result["visible"] = obj->property("visible").toBool();
-        // Geometry is painful cause QML uses its own "real" type (I don't even
-        // know if the coordinate system is the same as the rest) so TODO. :-)
+        // Geometry is painful cause QML uses its own "real" type - I don't even
+        // know if the coordinate system is the same as the rest - so TODO. :-)
     }
 
     // Include common identifying properties in tree nodes
@@ -1134,7 +1136,9 @@ QJsonArray InspectorServer::findByType(const QString &typeName, QWidget *root)
         QObject *obj = stack.takeFirst();
         if (!obj) continue;
 
-        // Don't process the same vertex more than once.
+        // Since we're merging the scene and object trees, this is a
+        // BFS on an arbitrary graph (could even contain cycles!).
+        // Mark visited vertices to avoid problems.
         if (visited.contains(obj)) continue;
         visited.insert(obj);
 

--- a/qt-plugin/inspectorserver.cpp
+++ b/qt-plugin/inspectorserver.cpp
@@ -823,7 +823,8 @@ QJsonObject InspectorServer::cmdFileDialogAction(const QJsonObject &params)
         if (fDialog) {
             fDialog->selectFile(params.value("path").toString());
         } else {
-            if (!obj->setProperty("selectedFile", QUrl(params.value("path").toString()))) {
+            QString fileUrl = "file://" + params.value("path").toString();
+            if (!obj->setProperty("selectedFile", QUrl(fileUrl))) {
                 qWarning() << "Failed to set selectedFile property on" << objectId;
             }
         }

--- a/qt-plugin/inspectorserver.cpp
+++ b/qt-plugin/inspectorserver.cpp
@@ -811,12 +811,13 @@ QJsonObject InspectorServer::cmdFileDialogAction(const QJsonObject &params)
     } else if (action == "cancel") {
         QMetaObject::invokeMethod(dialog, "reject");
     } else if (action == "select") {
-        if (isQDialog)
+        if (isQDialog) {
             QMetaObject::invokeMethod(dialog, "selectFile",
                 Q_ARG(QString, params.value("path").toString()));
-        else
+        } else {
             dialog->setProperty("selectedFile",
                 QVariant(QUrl(params.value("path").toString())));
+        }
     } else {
         return errorResult("Unknown action: " + action);
     }

--- a/qt-plugin/inspectorserver.cpp
+++ b/qt-plugin/inspectorserver.cpp
@@ -796,12 +796,12 @@ QJsonObject InspectorServer::cmdListFileDialogs(const QJsonObject &params) {
 QJsonObject InspectorServer::cmdFileDialogAction(const QJsonObject &params)
 {
     QString objectId = params.value("objectId").toString();
-    QObject *dialog = resolveObject(objectId);
-    if (!dialog)
+    QObject *obj = resolveObject(objectId);
+    if (!obj)
         return errorResult("Object not found: " + objectId);
 
-    bool isQDialog = dialog->inherits("QDialog");
-    if (!(isQDialog || dialog->inherits("QQuickFileDialog"))) {
+    QFileDialog *fDialog = qobject_cast<QFileDialog*>(obj);
+    if (!fDialog && !obj->inherits("QQuickFileDialog")) {
         return errorResult("Object is not a file dialog: " + objectId);
     }
 
@@ -809,15 +809,14 @@ QJsonObject InspectorServer::cmdFileDialogAction(const QJsonObject &params)
     // just use invokeMethod all over for simplicity.
     QString action = params.value("action").toString();
     if (action == "accept") {
-        QMetaObject::invokeMethod(dialog, "accept");
+        QMetaObject::invokeMethod(obj, "accept");
     } else if (action == "cancel") {
-        QMetaObject::invokeMethod(dialog, "reject");
+        QMetaObject::invokeMethod(obj, "reject");
     } else if (action == "select") {
-        if (isQDialog) {
-            QMetaObject::invokeMethod(dialog, "selectFile",
-                Q_ARG(QString, params.value("path").toString()));
+        if (fDialog) {
+            fDialog->selectFile(params.value("path").toString());
         } else {
-            dialog->setProperty("selectedFile",
+            obj->setProperty("selectedFile",
                 QVariant(QUrl(params.value("path").toString())));
         }
     } else {
@@ -878,6 +877,8 @@ QJsonObject InspectorServer::serializeObject(QObject *obj, int maxDepth, int cur
     // We need to resort to the metaobject protocol as QQuickDialog has no
     // public C++ API. This is, of course, brittle, and might break with
     // (minor) future versions releases of Qt.
+    // FIXME: this is getting pretty long, probably worth it to dismember this
+    //   into type-specific and keep the main traversal logic clean.
     if (obj->inherits("QQuickAbstractDialog")) {
         result["title"] = obj->property("title").toString();
         result["visible"] = obj->property("visible").toBool();

--- a/qt-plugin/inspectorserver.cpp
+++ b/qt-plugin/inspectorserver.cpp
@@ -1146,7 +1146,6 @@ QJsonArray InspectorServer::findByType(const QString &typeName, QWidget *root)
         // Match exact class name or a part of it (e.g., "Button" matches "QQuickButton" or
         // "Button_QML_TYPE_XX")
         if (className == typeName || className.contains(typeName)) {
-            QString id = registerObject(obj);
             results.append(serializeObject(obj, 0, 0));
         }
 

--- a/qt-plugin/inspectorserver.cpp
+++ b/qt-plugin/inspectorserver.cpp
@@ -823,8 +823,9 @@ QJsonObject InspectorServer::cmdFileDialogAction(const QJsonObject &params)
         if (fDialog) {
             fDialog->selectFile(params.value("path").toString());
         } else {
-            obj->setProperty("selectedFile",
-                QVariant(QUrl(params.value("path").toString())));
+            if (!obj->setProperty("selectedFile", QUrl(params.value("path").toString()))) {
+                qWarning() << "Failed to set selectedFile property on" << objectId;
+            }
         }
     } else {
         return errorResult("Unknown action: " + action);

--- a/qt-plugin/inspectorserver.cpp
+++ b/qt-plugin/inspectorserver.cpp
@@ -385,57 +385,8 @@ QJsonObject InspectorServer::cmdFindByType(const QJsonObject &params)
     if (!m_rootWidget)
         return errorResult("No root widget");
 
-    // Collect all objects and filter by type
-    QJsonArray results;
-    QList<QObject*> stack;
-    stack.append(m_rootWidget.data());
-
-    while (!stack.isEmpty()) {
-        QObject *obj = stack.takeFirst();
-        if (!obj) continue;
-
-        QString className = QString::fromUtf8(obj->metaObject()->className());
-        // Match exact class name or suffix (e.g., "Button" matches "QQuickButton")
-        if (className == typeName || className.endsWith(typeName)) {
-            QString id = registerObject(obj);
-            QJsonObject entry;
-            entry["id"] = id;
-            entry["type"] = className;
-            entry["objectName"] = obj->objectName();
-
-            QWidget *w = qobject_cast<QWidget*>(obj);
-            if (w) {
-                entry["geometry"] = QJsonObject{
-                    {"x", w->x()}, {"y", w->y()},
-                    {"width", w->width()}, {"height", w->height()}
-                };
-            }
-            QQuickItem *item = qobject_cast<QQuickItem*>(obj);
-            if (item) {
-                entry["geometry"] = QJsonObject{
-                    {"x", item->x()}, {"y", item->y()},
-                    {"width", item->width()}, {"height", item->height()}
-                };
-            }
-            results.append(entry);
-        }
-
-        // Traverse children
-        QQuickItem *item = qobject_cast<QQuickItem*>(obj);
-        if (item) {
-            for (auto *child : item->childItems())
-                stack.append(child);
-        }
-        // Also check QQuickWidget rootObject
-        QQuickWidget *qw = qobject_cast<QQuickWidget*>(obj);
-        if (qw && qw->rootObject()) {
-            stack.append(qw->rootObject());
-        }
-        for (auto *child : obj->children())
-            stack.append(child);
-    }
-
-    return okResult({{"matches", results}, {"count", results.size()}});
+    QJsonArray matches = findByType(typeName, m_rootWidget.data());
+    return okResult({{"matches", matches}, {"count", matches.size()}});
 }
 
 QJsonObject InspectorServer::cmdFindByProperty(const QJsonObject &params)
@@ -824,33 +775,48 @@ QJsonObject InspectorServer::cmdListInteractive(const QJsonObject &params)
 }
 
 QJsonObject InspectorServer::cmdListFileDialogs(const QJsonObject &params) {
+    // There are many more dialog types, but we start with those to make
+    // life simpler.
+    static const QStringList fileDialogTypes = {
+        "QFileDialog", "QQuickFileDialog"
+    };
+
     QWidgetList widgets = QApplication::topLevelWidgets();
-    QJsonArray roots;
-    for (QWidget *widget : widgets) {
-        QString className = widget->metaObject()->className();
-        if (className == "QFileDialog") {
-            roots.append(serializeObject(widget, 1));
+    QJsonArray dialogs;
+    for (QString dialogType : fileDialogTypes) {
+        for (QWidget *rootWidget : widgets) {
+            for(auto item : findByType(dialogType, rootWidget)) {
+                dialogs.append(item);
+            }
         }
     }
-    return okResult({{"dialogs", roots}});
+    return okResult({{"dialogs", dialogs}});
 }
 
 QJsonObject InspectorServer::cmdFileDialogAction(const QJsonObject &params)
 {
     QString objectId = params.value("objectId").toString();
-    QFileDialog *dialog = qobject_cast<QFileDialog*>(resolveObject(objectId));
-    if (!dialog) {
+    QObject *dialog = resolveObject(objectId);
+    if (!dialog)
+        return errorResult("Object not found: " + objectId);
+
+    bool isQDialog = dialog->inherits("QDialog");
+    if (!(isQDialog || dialog->inherits("QQuickAbstractDialog"))) {
         return errorResult("Object is not a file dialog: " + objectId);
     }
 
     QString action = params.value("action").toString();
     if (action == "accept") {
-        // accept is protected, so we have to resort to this.
         QMetaObject::invokeMethod(dialog, "accept");
     } else if (action == "cancel") {
-        dialog->reject();
+        QMetaObject::invokeMethod(dialog, "reject");
     } else if (action == "select") {
-        dialog->selectFile(params.value("path").toString());
+        if (isQDialog)
+            QMetaObject::invokeMethod(dialog, "selectFile",
+                Q_ARG(QString, params.value("path").toString()));
+        else
+            dialog->setProperty("selectedFile",
+                QVariant(QUrl(params.value("path").toString())));
     } else {
         return errorResult("Unknown action: " + action);
     }
@@ -892,6 +858,17 @@ QJsonObject InspectorServer::serializeObject(QObject *obj, int maxDepth, int cur
             {"width", item->width()}, {"height", item->height()}
         };
         result["opacity"] = item->opacity();
+    }
+
+    // QQuickFileDialog geometry.
+    // We need to resort to the metaobject protocol as QQuickDialog has no
+    // public C++ API. This is, of course, brittle, and might break with
+    // future versions maintenance releases of Qt.
+    if (obj->inherits("QQuickAbstractDialog")) {
+        result["title"] = obj->property("title").toString();
+        result["visible"] = obj->property("visible").toBool();
+        // Geometry is painful cause QML uses its own "real" type (I don't even
+        // know if the coordinate system is the same as the rest) so TODO. :-)
     }
 
     // Include common identifying properties in tree nodes
@@ -1142,4 +1119,43 @@ QJsonObject InspectorServer::okResult(const QJsonObject &data)
     QJsonObject result = data;
     result["ok"] = true;
     return result;
+}
+
+QJsonArray InspectorServer::findByType(const QString &typeName, QWidget *root)
+{
+    // Collect all objects and filter by type
+    QJsonArray results;
+    QSet<QObject*> visited;
+    QList<QObject*> stack;
+    stack.append(root);
+
+    while (!stack.isEmpty()) {
+        QObject *obj = stack.takeFirst();
+        if (!obj) continue;
+
+        // Don't process the same vertex more than once.
+        if (visited.contains(obj)) continue;
+        visited.insert(obj);
+
+        QString className = QString::fromUtf8(obj->metaObject()->className());
+        // Match exact class name or a part of it (e.g., "Button" matches "QQuickButton" or
+        // "Button_QML_TYPE_XX")
+        if (className == typeName || className.contains(typeName)) {
+            QString id = registerObject(obj);
+            results.append(serializeObject(obj, 0, 0));
+        }
+
+        QQuickItem *item = qobject_cast<QQuickItem*>(obj);
+        if (item) {
+            for (auto *child : item->childItems())
+                stack.append(child);
+        }
+        QQuickWidget *qw = qobject_cast<QQuickWidget*>(obj);
+        if (qw && qw->rootObject())
+            stack.append(qw->rootObject());
+        for (auto *child : obj->children())
+            stack.append(child);
+    }
+
+    return results;
 }

--- a/qt-plugin/inspectorserver.cpp
+++ b/qt-plugin/inspectorserver.cpp
@@ -863,6 +863,17 @@ QJsonObject InspectorServer::serializeObject(QObject *obj, int maxDepth, int cur
         result["opacity"] = item->opacity();
     }
 
+    // QDialog geometry.
+    QDialog *dialog = qobject_cast<QDialog*>(obj);
+    if (dialog) {
+        result["title"] = dialog->windowTitle();
+        result["visible"] = dialog->isVisible();
+        result["geometry"] = QJsonObject{
+            {"x", dialog->x()}, {"y", dialog->y()},
+            {"width", dialog->width()}, {"height", dialog->height()}
+        };
+    }
+
     // QQuickFileDialog geometry.
     // We need to resort to the metaobject protocol as QQuickDialog has no
     // public C++ API. This is, of course, brittle, and might break with

--- a/qt-plugin/inspectorserver.h
+++ b/qt-plugin/inspectorserver.h
@@ -53,6 +53,8 @@ private:
     QJsonObject cmdEvaluate(const QJsonObject &params);
     QJsonObject cmdFindAndClick(const QJsonObject &params);
     QJsonObject cmdListInteractive(const QJsonObject &params);
+    QJsonObject cmdListFileDialogs(const QJsonObject &params);
+    QJsonObject cmdFileDialogAction(const QJsonObject &params);
 
     // Tree serialization
     QJsonObject serializeObject(QObject *obj, int maxDepth, int currentDepth = 0);

--- a/qt-plugin/inspectorserver.h
+++ b/qt-plugin/inspectorserver.h
@@ -71,6 +71,7 @@ private:
     QWidget* findWidgetAt(int x, int y);
     QJsonObject errorResult(const QString &msg);
     QJsonObject okResult(const QJsonObject &data = QJsonObject());
+    QJsonArray findByType(const QString &typeName, QWidget * = nullptr);
 
     void sendResponse(QTcpSocket *socket, const QJsonObject &response);
 

--- a/test-framework/framework.mjs
+++ b/test-framework/framework.mjs
@@ -65,7 +65,9 @@ export class Inspector {
         const msg = JSON.parse(line);
         const p = this.pending.get(String(msg.id));
         if (p) { clearTimeout(p.timer); this.pending.delete(String(msg.id)); p.resolve(msg); }
-      } catch {}
+      } catch {
+        console.error("Error processing reply message:", line);
+      }
     }
   }
 
@@ -113,6 +115,20 @@ export class App {
   /** List all interactive elements. */
   async listInteractive() {
     return this.inspector.send("listInteractive", {});
+  }
+
+  /** List all file dialogs. */
+  async listFileDialogs() {
+    return this.inspector.send("listFileDialogs", {});
+  }
+
+  /** Interact with an existing dialog. */
+  async fileDialogAction(objectId, action, path = undefined) {
+    var params = { objectId, action };
+    if (path !== undefined) {
+      params.path = path;
+    }
+    return this.inspector.send("fileDialogAction", params);
   }
 
   /** Find elements by property value. */


### PR DESCRIPTION
This PR adds support for programmatically driving common file dialog types, required for things like selecting which plugin to install, which file to upload to storage, or where to save a file being downloaded by storage.

It adds two main commands to inspector, which percolate onto the test framework and the MCP server:

* `listDialogs` - lists file dialogs in the application. Might scoop in dialogs which are present but not visible (visible: false).
* `fileDialogAction` - issues an action to a dialog, which might be:
  * `accept` - accepts the current selection in the dialog and closes;
  * `cancel` - closes the dialog without accepting;
  * `select [path]` (e.g. `/home/foo`) - sets the selection to `[path]`.
  
This has a few limitations/problems. 
  
   1. there is no error feedback. If you accept/reject a dialog that's closed, or call select on an invalid file, things will simply not work and you will not know. This is because neither the [QDialog/QFileDialog](https://doc.qt.io/qt-6/qfiledialog.html) nor the [QtQuick Dialog](https://doc.qt.io/qt-6/qml-qtquick-dialogs-dialog.html) APIs provide such feedback, so neither can we;
   2. for QtQuick dialogs, selection after the dialog is open does not work. You need to FIRST call select (while the dialog is still closed) and THEN click whatever action opens the dialog. This is properly described in the MCP tool description so AI agents are aware of it.

I found issues in the way we've been traversing the Qt trees, so I rolled out a fix for my code path, which uses `findByType`. I believe the other code paths doing traversal (e.g. findAndClick) will require similar fixes, but I'll provide a separate PR for that.

I also had to change `cmdClick` to fire mouse clicks asynchronously as opening a modal dialog appears to block the event loop, and this was causing the server to not reply. Using `postEvent` instead of `sendEvent` seems to do the trick.