### PR TITLE
feat: adds MouseArea to list of interactive widgets

### DIFF
--- a/qt-plugin/inspectorserver.cpp
+++ b/qt-plugin/inspectorserver.cpp
@@ -742,16 +742,23 @@ QJsonObject InspectorServer::cmdListInteractive(const QJsonObject &params)
     static const QStringList interactiveTypes = {
         "Button", "Delegate", "TextField", "TextInput", "TextEdit",
         "ComboBox", "Slider", "Switch", "CheckBox", "RadioButton",
-        "SpinBox", "TabButton", "MenuItem"
+        "SpinBox", "TabButton", "MenuItem", "MouseArea"
     };
 
     QJsonArray results;
     QList<QObject*> stack;
+    QSet<QObject*> visited;
     stack.append(m_rootWidget.data());
 
     while (!stack.isEmpty()) {
         QObject *obj = stack.takeFirst();
         if (!obj) continue;
+
+        // Since we're merging the scene and object trees, this is a
+        // BFS on an arbitrary graph (could even contain cycles!).
+        // Mark visited vertices to avoid problems.
+        if (visited.contains(obj)) continue;
+        visited.insert(obj);
 
         QString className = QString::fromUtf8(obj->metaObject()->className());
 


### PR DESCRIPTION
This PR adds MouseArea to the list of interactive widgets, as that's often what is clickable. It also fixes a bug with widget graph traversal: since we're merging the scene and object graphs, the resulting graph is no longer a tree, so you need to guard against duplicate processing when running a BFS as we do.

Invoking `listInteractive` on master will produce large lists, often with thousands or tens of thousands of items, most of them repeated. With this patch you should get a more reasonable number with unique items.