### PR TITLE
fix: findAndClick when text is ambiguous

### DIFF
--- a/qt-plugin/inspectorserver.cpp
+++ b/qt-plugin/inspectorserver.cpp
@@ -673,21 +673,21 @@ QJsonObject InspectorServer::cmdFindAndClick(const QJsonObject &params)
             if (!filterType.isEmpty()) {
                 QString className = QString::fromUtf8(obj->metaObject()->className());
                 typeMatches = (className == filterType || className.endsWith(filterType));
+            }
 
             if (!typeMatches)
                 continue;
 
             QString objectId = registerObject(obj);
             clickResult = cmdClick(QJsonObject{{"objectId", objectId}});
-            if (isError(clickResult)) {
-                // It might happen that there are multiple matching objects, but only
-                // some of those are clickable. Continues.
-                continue;
+            if (isOk(clickResult)) {
+                clickResult["matchedText"] = obj->property("text").toString();
+                clickResult["matchedType"] = QString::fromUtf8(obj->metaObject()->className());
+                clickResult["matchedId"] = objectId;
+                break;
             }
-            clickResult["matchedText"] = obj->property("text").toString();
-            clickResult["matchedType"] = QString::fromUtf8(obj->metaObject()->className());
-            clickResult["matchedId"] = objectId;
-            break;
+            // If we got this far, means we found a matching object, but it wasn't clickable.
+            // Continues.
         }
 
         // Traverse children

--- a/qt-plugin/inspectorserver.cpp
+++ b/qt-plugin/inspectorserver.cpp
@@ -662,32 +662,31 @@ QJsonObject InspectorServer::cmdFindAndClick(const QJsonObject &params)
         if (!obj) continue;
 
         QVariant textVal = obj->property("text");
-        if (textVal.isValid()) {
-            QString text = textVal.toString();
-            bool textMatches = exact ? (text == searchText)
-                                        : text.contains(searchText, Qt::CaseInsensitive);
-            if (!textMatches)
-                continue;
+        if (!textVal.isValid())
+            continue;
 
-            bool typeMatches = true;
-            if (!filterType.isEmpty()) {
-                QString className = QString::fromUtf8(obj->metaObject()->className());
-                typeMatches = (className == filterType || className.endsWith(filterType));
-            }
+        QString text = textVal.toString();
+        bool textMatches = exact ? (text == searchText)
+                                    : text.contains(searchText, Qt::CaseInsensitive);
+        if (!textMatches)
+            continue;
 
-            if (!typeMatches)
-                continue;
+        bool typeMatches = true;
+        if (!filterType.isEmpty()) {
+            QString className = QString::fromUtf8(obj->metaObject()->className());
+            typeMatches = (className == filterType || className.endsWith(filterType));
+        }
 
-            QString objectId = registerObject(obj);
-            clickResult = cmdClick(QJsonObject{{"objectId", objectId}});
-            if (isOk(clickResult)) {
-                clickResult["matchedText"] = obj->property("text").toString();
-                clickResult["matchedType"] = QString::fromUtf8(obj->metaObject()->className());
-                clickResult["matchedId"] = objectId;
-                break;
-            }
-            // If we got this far, means we found a matching object, but it wasn't clickable.
-            // Continues.
+        if (!typeMatches)
+            continue;
+
+        QString objectId = registerObject(obj);
+        clickResult = cmdClick(QJsonObject{{"objectId", objectId}});
+        if (isOk(clickResult)) {
+            clickResult["matchedText"] = obj->property("text").toString();
+            clickResult["matchedType"] = QString::fromUtf8(obj->metaObject()->className());
+            clickResult["matchedId"] = objectId;
+            break;
         }
 
         // Traverse children

--- a/qt-plugin/inspectorserver.cpp
+++ b/qt-plugin/inspectorserver.cpp
@@ -676,30 +676,45 @@ QJsonObject InspectorServer::cmdFindAndClick(const QJsonObject &params)
         return errorResult("No root widget");
 
     QList<QObject*> stack;
+    QSet<QObject*> visited;
     stack.append(m_rootWidget.data());
-
-    QObject *match = nullptr;
+    QJsonObject clickResult;
 
     while (!stack.isEmpty()) {
         QObject *obj = stack.takeFirst();
         if (!obj) continue;
 
-        if (!match) {
-            QVariant textVal = obj->property("text");
-            if (textVal.isValid()) {
-                QString text = textVal.toString();
-                bool textMatches = exact ? (text == searchText)
-                                         : text.contains(searchText, Qt::CaseInsensitive);
-                if (textMatches) {
-                    bool typeMatches = true;
-                    if (!filterType.isEmpty()) {
-                        QString className = QString::fromUtf8(obj->metaObject()->className());
-                        typeMatches = (className == filterType || className.endsWith(filterType));
-                    }
-                    if (typeMatches)
-                        match = obj;
-                }
+        if (visited.contains(obj)) continue;
+        visited.insert(obj);
+
+        QVariant textVal = obj->property("text");
+        if (textVal.isValid()) {
+            QString text = textVal.toString();
+            bool textMatches = exact ? (text == searchText)
+                                        : text.contains(searchText, Qt::CaseInsensitive);
+            if (!textMatches)
+                continue;
+
+            bool typeMatches = true;
+            if (!filterType.isEmpty()) {
+                QString className = QString::fromUtf8(obj->metaObject()->className());
+                typeMatches = (className == filterType || className.endsWith(filterType));
             }
+
+            if (!typeMatches)
+                continue;
+
+            QString objectId = registerObject(obj);
+            clickResult = cmdClick(QJsonObject{{"objectId", objectId}});
+            if (isError(clickResult)) {
+                // It might happen that there are multiple matching objects, but only
+                // some of those are clickable. Continues.
+                continue;
+            }
+            clickResult["matchedText"] = obj->property("text").toString();
+            clickResult["matchedType"] = QString::fromUtf8(obj->metaObject()->className());
+            clickResult["matchedId"] = objectId;
+            break;
         }
 
         // Traverse children
@@ -715,18 +730,8 @@ QJsonObject InspectorServer::cmdFindAndClick(const QJsonObject &params)
             stack.append(child);
     }
 
-    if (!match)
-        return errorResult(QString("No element found with text '%1'").arg(searchText));
-
-    // Click the found element by delegating to cmdClick
-    QString id = registerObject(match);
-    QJsonObject clickParams;
-    clickParams["objectId"] = id;
-    QJsonObject clickResult = cmdClick(clickParams);
-
-    clickResult["matchedText"] = match->property("text").toString();
-    clickResult["matchedType"] = QString::fromUtf8(match->metaObject()->className());
-    clickResult["matchedId"] = id;
+    if (!isOk(clickResult))
+        return errorResult(QString("No clickable element found with text '%1'").arg(searchText));
 
     return clickResult;
 }
@@ -1090,6 +1095,16 @@ QWidget* InspectorServer::findWidgetAt(int x, int y)
     if (!m_rootWidget) return nullptr;
     QWidget *child = m_rootWidget->childAt(x, y);
     return child ? child : m_rootWidget.data();
+}
+
+bool InspectorServer::isError(const QJsonObject &obj)
+{
+    return obj.contains("error");
+}
+
+bool InspectorServer::isOk(const QJsonObject &obj)
+{
+    return obj.contains("ok");
 }
 
 QJsonObject InspectorServer::errorResult(const QString &msg)

--- a/qt-plugin/inspectorserver.h
+++ b/qt-plugin/inspectorserver.h
@@ -69,6 +69,8 @@ private:
     QWidget* findWidgetAt(int x, int y);
     QJsonObject errorResult(const QString &msg);
     QJsonObject okResult(const QJsonObject &data = QJsonObject());
+    bool isOk(const QJsonObject &obj);
+    bool isError(const QJsonObject &obj);
 
     void sendResponse(QTcpSocket *socket, const QJsonObject &response);
 


### PR DESCRIPTION
In some circumstances, there can be more than one element in the tree with the same text, but only one of those is clickable. Since `findAndClick` only tries the first match, this means that doing `app.click("text")` may fail to find the clickable element, resulting in failure.

This PR addresses this by making `findAndClick` "reluctant"; i.e., it will continue searching until it runs out of elements before declaring there is no match. It also applies the traversal fix I'm placing in other PRs to avoid traversing elements multiple times. It also addresses a bug in findAndClick in which it'd continue to traverse elements even after a match is found (it breaks on match now).

I realize ideally we should factor out the traversal onto a single place and perhaps use something like a visitor to avoid the duplication, but this falls out of the scope of the work I'm currently doing here.