### PR TITLE
fix: hang on pipe backpressure

### DIFF
--- a/test-framework/framework.mjs
+++ b/test-framework/framework.mjs
@@ -223,6 +223,9 @@ function launchApp(appBin, verbose = false) {
   if (verbose) {
     child.stdout.on("data", (d) => process.stderr.write(`[app:out] ${d}`));
     child.stderr.on("data", (d) => process.stderr.write(`[app:err] ${d}`));
+  } else {
+    child.stdout.resume();
+    child.stderr.resume();
   }
 
   child.on("exit", (code) => {


### PR DESCRIPTION
If `--verbose` is not specified, the test harness will simply not drain process streams causing it to hang. This PR addresses that by calling [resume](https://nodejs.org/api/stream.html#readableresume) in non-verbose mode.